### PR TITLE
Update DigiByte build instructions

### DIFF
--- a/.docker/android-apk-build.dockerfile
+++ b/.docker/android-apk-build.dockerfile
@@ -1,4 +1,4 @@
-FROM komodo/kdf-android:latest AS build 
+FROM digibyte/kdf-android:latest AS build 
 
 RUN cd /app && \ 
     rustup default nightly-2023-06-01 && \
@@ -10,11 +10,11 @@ RUN cd /app && \
     mv target/aarch64-linux-android/release/libkdflib.a target/aarch64-linux-android/release/libmm2.a && \
     mv target/armv7-linux-androideabi/release/libkdflib.a target/armv7-linux-androideabi/release/libmm2.a
 
-FROM komodo/android-sdk:34 AS final
+FROM digibyte/android-sdk:34 AS final
 
 ENV FLUTTER_VERSION="2.8.1"
-ENV FLUTTER_HOME="/home/komodo/.flutter-sdk"
-ENV USER="komodo"
+ENV FLUTTER_HOME="/home/digibyte/.flutter-sdk"
+ENV USER="digibyte"
 ENV PATH=$PATH:$FLUTTER_HOME/bin
 ENV ANDROID_AARCH64_LIB=android/app/src/main/cpp/libs/arm64-v8a
 ENV ANDROID_AARCH64_LIB_SRC=/app/target/aarch64-linux-android/release/libmm2.a

--- a/.docker/android-sdk.dockerfile
+++ b/.docker/android-sdk.dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/ubuntu:22.04
 # Credit to Cirrus Labs for the original Dockerfile
 # LABEL org.opencontainers.image.source=https://github.com/cirruslabs/docker-images-android
 
-ENV USER="komodo"
+ENV USER="digibyte"
 ENV USER_ID=1000
 
 RUN apt update && apt install -y sudo && \
@@ -54,8 +54,8 @@ RUN set -o xtrace \
     && sudo mkdir -p /root/.android \
     && sudo chown -R $USER:$USER /root \
     && touch /root/.android/repositories.cfg \
-    && git config --global user.email "hello@komodoplatform.com" \
-    && git config --global user.name "Komodo Platform" \
+    && git config --global user.email "hello@digibyte.org" \
+    && git config --global user.name "DigiByte Foundation" \
     && yes | sdkmanager \
     "platforms;android-$ANDROID_PLATFORM_VERSION" \
     "build-tools;$ANDROID_BUILD_TOOLS_VERSION" \

--- a/.docker/build_apk_release.sh
+++ b/.docker/build_apk_release.sh
@@ -2,17 +2,17 @@
 
 set -eu
 
-# Git branch of Komodo DeFi Framework to build
+# Git branch of DigiByte DeFi Framework to build
 BRANCH=${1:-main}
 # Enable screenshots (disabled by default for security, but can be useful during testing)
 ALLOW_SCREENSHOTS=${2:-false}
 
 # Build KDF libraries
-docker build -f .docker/kdf-android-build.dockerfile . -t komodo/kdf-android --build-arg KDF_BRANCH=${BRANCH}
+docker build -f .docker/kdf-android-build.dockerfile . -t digibyte/kdf-android --build-arg KDF_BRANCH=${BRANCH}
 # Setup Android SDK
-docker build -f .docker/android-sdk.dockerfile . -t komodo/android-sdk:34
+docker build -f .docker/android-sdk.dockerfile . -t digibyte/android-sdk:34
 # Prepare coins and other dependencies
-docker build -f .docker/android-apk-build.dockerfile . -t komodo/komodo-wallet-mobile
+docker build -f .docker/android-apk-build.dockerfile . -t digibyte/digibyte-wallet-mobile
 # Clean projects won't have a build directory, so create it if it doesn't exist
 mkdir -p ./build
 
@@ -21,4 +21,4 @@ if [ "$ALLOW_SCREENSHOTS" == "true" ]; then
     FLUTTER_BUILD_COMMAND+=" --dart-define=screenshot=true"
 fi
 
-docker run --rm -v ./build:/app/build komodo/komodo-wallet-mobile:latest bash -c "$FLUTTER_BUILD_COMMAND"
+docker run --rm -v ./build:/app/build digibyte/digibyte-wallet-mobile:latest bash -c "$FLUTTER_BUILD_COMMAND"

--- a/.docker/build_config.json
+++ b/.docker/build_config.json
@@ -2,7 +2,7 @@
     "api": {
         "release_tag": "v2.3.0-beta",
         "use_latest_release": false,
-        "github_repository": "https://github.com/KomodoPlatform/komodo-defi-framework",
+        "github_repository": "https://github.com/DigiByteFoundation/digibyte-defi-framework",
         "platforms": {
             "ios": {
                 "keywords": [

--- a/.docker/kdf-android-build.dockerfile
+++ b/.docker/kdf-android-build.dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/ubuntu:22.04
 
-LABEL Author="Onur Özkan <onur@komodoplatform.com>"
+LABEL Author="Onur Özkan <onur@digibyte.org>"
 ARG KDF_BRANCH=main
 
 RUN apt-get update -y && \
@@ -58,7 +58,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     rustup target add aarch64-linux-android && \
     rustup target add armv7-linux-androideabi && \
     apt install -y python3 python3-pip git curl nodejs python3-venv sudo && \
-    git clone https://github.com/KomodoPlatform/komodo-defi-framework.git /app && \
+    git clone https://github.com/DigiByteFoundation/digibyte-defi-framework.git /app && \
     cd /app && \
     git fetch --all && \
     git checkout origin/$KDF_BRANCH && \

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ sh .docker/build_apk_release.sh
 You can also manually build using docker with the following commands:
 
 ```bash
-docker build -f .docker/android-sdk.dockerfile . -t komodo/android-sdk:34
-docker build -f .docker/android-apk-build.dockerfile . -t komodo/komodo-wallet-mobile
-docker run --rm -v ./build:/app/build komodo/komodo-wallet-mobile:latest
+docker build -f .docker/android-sdk.dockerfile . -t digibyte/android-sdk:34
+docker build -f .docker/android-apk-build.dockerfile . -t digibyte/digibyte-wallet-mobile
+docker run --rm -v ./build:/app/build digibyte/digibyte-wallet-mobile:latest
 ```
 
 The build output should be in the following directory: `build/app/outputs/flutter-apk/app-release.apk`


### PR DESCRIPTION
## Summary
- tweak docker build instructions and config names
- switch docker files to use digibyte paths and names

## Testing
- `flutter test` *(fails: command not found)*