### PR TITLE
Fix duplicate walletOnlyCoins getter

### DIFF
--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -55,13 +55,6 @@ class AppConfig {
   List<String> get defaultCoins => ['DGB', 'BTC-segwit', 'KMD'];
   List<String> get coinsFiat     => ['BTC-segwit', 'DGB'];
 
-  // the existing wallet-only coins
-  List<String> get walletOnlyCoins => [
-    'AAVE-FTM20',
-    'AGIX-ERC20',
-    // …etc.
-  ];
-
   List<String> get walletOnlyCoins => [
         'AAVE-FTM20',
         'AGIX-ERC20',


### PR DESCRIPTION
## Summary
- remove duplicate `walletOnlyCoins` getter causing build failure

## Testing
- `flutter` commands were not run because Flutter is not installed in the environment