### PR TITLE
Fix ticker test list expectation

### DIFF
--- a/test/coin_ticker_test.dart
+++ b/test/coin_ticker_test.dart
@@ -16,7 +16,7 @@ void main() {
       final List<String> tickers =
           symbols.map((String symbol) => getCoinTicker(symbol)).toList();
 
-      expect(tickers, tickers.map((_) => 'KMD'));
+      expect(tickers, everyElement('KMD'));
     });
 
     test(
@@ -28,7 +28,7 @@ void main() {
       final List<String> tickers =
           symbols.map((String symbol) => getCoinTicker(symbol)).toList();
 
-      expect(tickers, tickers.map((_) => 'KMD old').toList());
+      expect(tickers, everyElement('KMD old'));
     });
 
     test('returns the input for invalid abbreviation', () {


### PR DESCRIPTION
## Summary
- fix assertion on ticker list to properly collect results
- use matchers for ticker arrays

## Testing
- `flutter test` *(fails: command not found)*